### PR TITLE
Ink stable

### DIFF
--- a/ink/old.Dockerfile
+++ b/ink/old.Dockerfile
@@ -46,25 +46,22 @@ RUN set -eux;\
     cmake . && make; \
     cp bin/wasm-opt /usr/local/bin; \
     popd; \
-    rm -rf binaryen; \
-    rustup default $NIGHTLY_VERSION; \
-    rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY_VERSION; \
-    rustup component add rust-src;
-
-RUN set -eux;\
-    \
-    mkdir -p /projects/sample;
-
-COPY ./sample/ /projects/sample
-
-WORKDIR /projects/sample
+    rm -rf binaryen;
 
 RUN set -eux; \
     \
+    rustup default $NIGHTLY_VERSION; \
+    rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY_VERSION; \
+    rustup component add rust-src; \
+    mkdir /projects; \
+    cd /projects; \
+    cargo contract new sample; \
+    cd sample; \
     cargo contract build; \
     cargo contract generate-metadata; \
     rm target/sample* target/metadata.json;
 
+WORKDIR /projects/sample
 
 CMD rm ./lib.rs; \
     cp -f "/share/${NONCE}.rs" ./lib.rs; \

--- a/ink/sample/.gitignore
+++ b/ink/sample/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/ink/sample/.ink/abi_gen/Cargo.toml
+++ b/ink/sample/.ink/abi_gen/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "abi-gen"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+publish = false
+
+[[bin]]
+name = "abi-gen"
+path = "main.rs"
+
+[dependencies]
+contract = { path = "../..", package = "sample", default-features = false, features = ["ink-generate-abi"] }
+ink_lang = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_lang", default-features = false, features = ["ink-generate-abi"] }
+serde = "1.0"
+serde_json = "1.0"

--- a/ink/sample/.ink/abi_gen/Cargo.toml
+++ b/ink/sample/.ink/abi_gen/Cargo.toml
@@ -11,6 +11,6 @@ path = "main.rs"
 
 [dependencies]
 contract = { path = "../..", package = "sample", default-features = false, features = ["ink-generate-abi"] }
-ink_lang = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_lang", default-features = false, features = ["ink-generate-abi"] }
+ink_lang = { version = "2", git = "https://github.com/staketechnologies/ink", branch = "ink-playground-master", package = "ink_lang", default-features = false, features = ["ink-generate-abi"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/ink/sample/.ink/abi_gen/main.rs
+++ b/ink/sample/.ink/abi_gen/main.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), std::io::Error> {
+    let abi = <contract::Sample as ink_lang::GenerateAbi>::generate_abi();
+    let contents = serde_json::to_string_pretty(&abi)?;
+    std::fs::create_dir("target").ok();
+    std::fs::write("target/metadata.json", contents)?;
+    Ok(())
+}

--- a/ink/sample/Cargo.toml
+++ b/ink/sample/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2018"
 
 [dependencies]
-ink_abi = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_abi", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_primitives", default-features = false }
-ink_core = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_core", default-features = false }
-ink_lang = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_lang", default-features = false }
+ink_abi = { version = "2", git = "https://github.com/staketechnologies/ink", branch = "ink-playground-master", package = "ink_abi", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "2", git = "https://github.com/staketechnologies/ink", branch = "ink-playground-master", package = "ink_primitives", default-features = false }
+ink_core = { version = "2", git = "https://github.com/staketechnologies/ink", branch = "ink-playground-master", package = "ink_core", default-features = false }
+ink_lang = { version = "2", git = "https://github.com/staketechnologies/ink", branch = "ink-playground-master", package = "ink_lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.2", default-features = false, features = ["derive"] }
 

--- a/ink/sample/Cargo.toml
+++ b/ink/sample/Cargo.toml
@@ -1,0 +1,67 @@
+[package]
+name = "sample"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2018"
+
+[dependencies]
+ink_abi = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_abi", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_primitives", default-features = false }
+ink_core = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_core", default-features = false }
+ink_lang = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_lang", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "1.2", default-features = false, features = ["derive"] }
+
+[dependencies.type-metadata]
+git = "https://github.com/type-metadata/type-metadata.git"
+rev = "02eae9f35c40c943b56af5b60616219f2b72b47d"
+default-features = false
+features = ["derive"]
+optional = true
+
+[lib]
+name = "sample"
+path = "lib.rs"
+crate-type = [
+	# Used for normal contract Wasm blobs.
+	"cdylib",
+	# Required for ABI generation, and using this contract as a dependency.
+	# If using `cargo contract build`, it will be automatically disabled to produce a smaller Wasm binary
+	"rlib",
+]
+
+[features]
+default = ["test-env"]
+std = [
+    "ink_abi/std",
+    "ink_core/std",
+    "ink_primitives/std",
+    "scale/std",
+    "type-metadata/std",
+]
+test-env = [
+    "std",
+    "ink_lang/test-env",
+]
+ink-generate-abi = [
+    "std",
+    "ink_abi",
+    "type-metadata",
+    "ink_core/ink-generate-abi",
+    "ink_lang/ink-generate-abi",
+]
+ink-as-dependency = []
+
+[profile.release]
+panic = "abort"
+lto = true
+opt-level = "z"
+overflow-checks = true
+
+[workspace]
+members = [
+	".ink/abi_gen"
+]
+exclude = [
+	".ink"
+]

--- a/ink/sample/lib.rs
+++ b/ink/sample/lib.rs
@@ -1,0 +1,76 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use ink_lang as ink;
+
+#[ink::contract(version = "0.1.0")]
+mod sample {
+    use ink_core::storage;
+
+    /// Defines the storage of your contract.
+    /// Add new fields to the below struct in order
+    /// to add new static storage fields to your contract.
+    #[ink(storage)]
+    struct Sample {
+        /// Stores a single `bool` value on the storage.
+        value: storage::Value<bool>,
+    }
+
+    impl Sample {
+        /// Constructor that initializes the `bool` value to the given `init_value`.
+        #[ink(constructor)]
+        fn new(&mut self, init_value: bool) {
+            self.value.set(init_value);
+        }
+
+        /// Constructor that initializes the `bool` value to `false`.
+        ///
+        /// Constructors can delegate to other constructors.
+        #[ink(constructor)]
+        fn default(&mut self) {
+            self.new(false)
+        }
+
+        /// A message that can be called on instantiated contracts.
+        /// This one flips the value of the stored `bool` from `true`
+        /// to `false` and vice versa.
+        #[ink(message)]
+        fn flip(&mut self) {
+            *self.value = !self.get();
+        }
+
+        /// Simply returns the current value of our `bool`.
+        #[ink(message)]
+        fn get(&self) -> bool {
+            *self.value
+        }
+    }
+
+    /// Unit tests in Rust are normally defined within such a `#[cfg(test)]`
+    /// module and test functions are marked with a `#[test]` attribute.
+    /// The below code is technically just normal Rust code.
+    #[cfg(test)]
+    mod tests {
+        /// Imports all the definitions from the outer scope so we can use them here.
+        use super::*;
+
+        /// We test if the default constructor does its job.
+        #[test]
+        fn default_works() {
+            // Note that even though we defined our `#[ink(constructor)]`
+            // above as `&mut self` functions that return nothing we can call
+            // them in test code as if they were normal Rust constructors
+            // that take no `self` argument but return `Self`.
+            let sample = Sample::default();
+            assert_eq!(sample.get(), false);
+        }
+
+        /// We test a simple use case of our contract.
+        #[test]
+        fn it_works() {
+            let mut sample = Sample::new(false);
+            assert_eq!(sample.get(), false);
+            sample.flip();
+            assert_eq!(sample.get(), true);
+        }
+    }
+}


### PR DESCRIPTION
Not using "cargo contract new" internally.
It is now holding the template ink project in the repository, and referring forked ink repository.